### PR TITLE
Disable create(..) if addPath is falsey

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -82,7 +82,7 @@ class Backend {
     const payload = this.options.parsePayload(namespace, key, fallbackValue)
     languages.forEach(lng => {
       // If there is a falsey addPath, then abort -- this has been disabled.
-      if (!this.options.addPath) return;
+      if (!this.options.addPath) return
 
       const url = this.services.interpolator.interpolate(this.options.addPath, { lng: lng, ns: namespace })
       this.options.request(this.options, url, payload, (data, res) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -81,6 +81,9 @@ class Backend {
     if (typeof languages === 'string') languages = [languages]
     const payload = this.options.parsePayload(namespace, key, fallbackValue)
     languages.forEach(lng => {
+      // If there is a falsey addPath, then abort -- this has been disabled.
+      if (!this.options.addPath) return;
+
       const url = this.services.interpolator.interpolate(this.options.addPath, { lng: lng, ns: namespace })
       this.options.request(this.options, url, payload, (data, res) => {
         // TODO: if res.status === 4xx do log


### PR DESCRIPTION
If the specified addPath value is falsey, then do not execute the
creation request. This addMissing flow might be handled by other
backends which have been installed.