### PR TITLE
Fix crash ./getFetch.cjs

### DIFF
--- a/lib/getFetch.cjs
+++ b/lib/getFetch.cjs
@@ -1,6 +1,0 @@
-if (typeof require !== 'undefined') {
-  var f = require('node-fetch')
-  if (f.default) f = f.default
-  exports.default = f
-  module.exports = exports.default
-}

--- a/lib/getFetch.js
+++ b/lib/getFetch.js
@@ -1,0 +1,3 @@
+var f = require('node-fetch')
+if (f.default) f = f.default
+expect default f

--- a/lib/getFetch.js
+++ b/lib/getFetch.js
@@ -1,3 +1,3 @@
 var f = require('node-fetch')
 if (f.default) f = f.default
-expect default f
+export default f

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,4 +1,4 @@
-import * as fetchNode from './getFetch.cjs'
+import fetchNode from './getFetch.js'
 
 let fetchApi
 if (typeof fetch === 'function') {


### PR DESCRIPTION
 Crash on ReactNative 0.61.5 and React 0.16.9,