### PR TITLE
Use `getRequestOptions` instead of `requestOptions` for flexibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ i18next.use(Backend).init(i18nextOptions);
     // ...
   },
 
-  requestOptions: { // used for fetch
+  getRequestOptions: payload => ({ // used for fetch
     mode: 'cors',
     credentials: 'same-origin',
     cache: 'default'
-  }
+  })
 
   // define a custom request function
   // can be used to support XDomainRequest in IE 8 and 9

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,11 +16,11 @@ const getDefaults = () => {
     crossDomain: false, // used for XmlHttpRequest
     withCredentials: false, // used for XmlHttpRequest
     overrideMimeType: false, // used for XmlHttpRequest
-    requestOptions: { // used for fetch
+    getRequestOptions: payload => ({ // used for fetch
       mode: 'cors',
       credentials: 'same-origin',
       cache: 'default'
-    }
+    })
   }
 }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -50,7 +50,7 @@ const requestWithFetch = (options, url, payload, callback) => {
     method: payload ? 'POST' : 'GET',
     body: payload ? options.stringify(payload) : undefined,
     headers,
-    ...options.srequestOptions
+    ...options.getRequestOptions(payload)
   }).then((response) => {
     if (!response.ok) return callback(response.statusText || 'Error', { status: response.status })
     response.text().then((data) => {


### PR DESCRIPTION
`options.getRequestOptions` would give the devs more flexibility, eg. Cloudfare workers do not support `fetch` with method `POST` and `mode: "cors", while `GET` is supported.