### PR TITLE
Fix deno example run error

### DIFF
--- a/example/deno/README.md
+++ b/example/deno/README.md
@@ -1,6 +1,6 @@
 # just like usual...
 
-```js
+```ts
 import i18next from 'https://deno.land/x/i18next/index.js'
 
 i18next.init({
@@ -17,7 +17,7 @@ i18next.init({
       }
     }
   }
-}, (err, t) => {
+}, (err: Error, t: (...params: any[]) => string) => {
   if (err) return console.error(err)
   console.log(t('welcome')) // hello world
   console.log(t('welcome', { lng: 'de' })) // hallo welt
@@ -26,7 +26,7 @@ i18next.init({
 
 ## example with http backend
 
-```js
+```ts
 // serve translations
 import { Application } from 'https://deno.land/x/abc/mod.ts'
 (new Application())
@@ -46,7 +46,7 @@ i18next.use(HttpBackend).init({
   backend: {
     loadPath: 'http://localhost:8080/locales/{{lng}}/{{ns}}.json'
   }
-}, (err, t) => {
+}, (err: Error, t: (...params: any[]) => string) => {
   if (err) return console.error(err)
   console.log(t('welcome')) // hello world
   console.log(t('welcome', { lng: 'de' })) // hallo welt
@@ -56,5 +56,5 @@ i18next.use(HttpBackend).init({
 ### run the example (app.js) with:
 
 ```sh
-deno --allow-net --allow-env --allow-read app.js
+deno run --allow-net --allow-env --allow-read app.ts
 ```

--- a/example/deno/app.ts
+++ b/example/deno/app.ts
@@ -20,7 +20,7 @@ i18next.use(HttpBackend).init({
   backend: {
     loadPath: 'http://localhost:8080/locales/{{lng}}/{{ns}}.json'
   }
-}, (err, t) => {
+}, (err: Error, t: (...params: any[]) => string) => {
   if (err) return console.error(err)
   console.log(t('welcome'))
   console.log(t('welcome', { lng: 'de' }))


### PR DESCRIPTION
Currently, when we follow the README to run the deno example, it produce an error:

```
error: Uncaught AssertionError: Unexpected skip of the emit.
    at Object.assert ($deno$/util.ts:33:11)
    at compile ($deno$/compiler.ts:1170:7)
    at tsCompilerOnMessage ($deno$/compiler.ts:1338:22)
    at workerMessageRecvCallback ($deno$/runtime_worker.ts:72:33)
    at file:///Users/<User>/Documents/<repo>/example/deno/__anonymous__:1:1
```

#### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test`
- [ ] tests are included
- [x] documentation is changed or added