### PR TITLE
update dep for npm advisory 1556

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "module": "./esm/index.js",
   "dependencies": {
-    "node-fetch": "2.6.0"
+    "node-fetch": "~2.6.1"
   },
   "types": "./index.d.ts",
   "devDependencies": {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->
NPM Audit has new security advisory regarding node-fetch library. A new fixed version (patch level) exists and should be used. As this project requires n explicit version it does not automatically use the fixed version and all dependent projects of this gets a warning.

┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Denial of Service                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ node-fetch                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.6.1 <3.0.0-beta.1|| >= 3.0.0-beta.9                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ i18next-http-backend                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ i18next-http-backend > node-fetch                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1556                            │
└───────────────┴──────────────────────────────────────────────────────────────┘

This PR updates the node-fetch dependency to the fixed version (2.6.0 -> 2.6.1) and loosens the requirement a bit to allow future bugfix versions to be automatically used.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test` - see below
- [ ] tests are included - no new tests needed
- [ ] documentation is changed or added - no update needed as far as i can see

Tests do not run successful, but they do not even run on my system without my change. Your current version fails here too on this point:
```
> i18next-http-backend@1.0.18 test:fetch /home/stefan/workspaces/github-forks/i18next-http-backend
> mocha test -R spec --exit --experimental-modules

(node:20492) ExperimentalWarning: The ESM module loader is experimental.

/home/stefan/workspaces/github-forks/i18next-http-backend/test/backendConnector.load.spec.js:1
import expect from 'expect.js'
       ^^^^^^

SyntaxError: Unexpected identifier
    at Module._compile (internal/modules/cjs/loader.js:723:23)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    ...
```