### PR TITLE
Update readme of loadPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ i18next.use(Backend).init(i18nextOptions);
   // returning a path:
   // function(lngs, namespaces) { return customPath; }
   // the returned path will interpolate lng, ns if provided like giving a static path
+  //
+  // If allowMultiLoading is false, lngs and namespaces will have only one element each,
+  // If allowMultiLoading is true, lngs and namespaces can have multiple elements
   loadPath: '/locales/{{lng}}/{{ns}}.json',
 
   // path to post missing resources


### PR DESCRIPTION
This PR is more like a question, but also updates the documentation.

The `loadPath` config takes a function `(lngs, namespaces) => path`. Both arguments are arrays but it is not clear when can they have more than one element.

My guess is that this happens only when multiloading is enabled. Is this true? If so, the relationship between `loadPath` and `allowMultiLoading` can be mentioned more explicitly (this PR).

I've checked the codes of i18next-http-backend, i18next itself, i18next-multiload-adapter but couldn't find the answer to this question.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] documentation is changed or added