### PR TITLE
Accept XMLHttpRequest as an object

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -1,4 +1,4 @@
-import { defaults } from './utils.js'
+import { defaults, hasXMLHttpRequest } from './utils.js'
 import * as fetchNode from './getFetch.cjs'
 
 let fetchApi
@@ -10,7 +10,7 @@ if (typeof fetch === 'function') {
   }
 }
 let XmlHttpRequestApi
-if (typeof XMLHttpRequest === 'function') {
+if (hasXMLHttpRequest) {
   if (typeof global !== 'undefined' && global.XMLHttpRequest) {
     XmlHttpRequestApi = global.XMLHttpRequest
   } else if (typeof window !== 'undefined' && window.XMLHttpRequest) {
@@ -118,7 +118,7 @@ const request = (options, url, payload, callback) => {
     return requestWithFetch(options, url, payload, callback)
   }
 
-  if (typeof XMLHttpRequest === 'function' || typeof ActiveXObject === 'function') {
+  if (hasXMLHttpRequest || typeof ActiveXObject === 'function') {
     // use xml http request
     return requestWithXmlHttpRequest(options, url, payload, callback)
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,3 +12,7 @@ export function defaults (obj) {
   })
   return obj
 }
+
+export function hasXMLHttpRequest () {
+  return (typeof XMLHttpRequest === 'function' || typeof XMLHttpRequest === 'object')
+}

--- a/test/http.spec.js
+++ b/test/http.spec.js
@@ -3,10 +3,11 @@ import Http from '../index.js'
 import i18next from 'i18next'
 import JSON5 from 'json5'
 import server from './fixtures/server.js'
+import { hasXMLHttpRequest } from '../lib/utils.js'
 
 i18next.init()
 
-describe(`http backend using ${typeof XMLHttpRequest === 'function' ? 'XMLHttpRequest' : 'fetch'}`, () => {
+describe(`http backend using ${hasXMLHttpRequest ? 'XMLHttpRequest' : 'fetch'}`, () => {
   before(server)
 
   describe('#read', () => {

--- a/test/request.spec.js
+++ b/test/request.spec.js
@@ -1,8 +1,9 @@
 import expect from 'expect.js'
 import request from '../lib/request.js'
 import server from './fixtures/server.js'
+import { hasXMLHttpRequest } from '../lib/utils.js'
 
-describe(`request ${typeof XMLHttpRequest === 'function' ? 'XMLHttpRequest' : 'fetch'}`, () => {
+describe(`request ${hasXMLHttpRequest ? 'XMLHttpRequest' : 'fetch'}`, () => {
   before(server)
 
   describe('#missing', () => {


### PR DESCRIPTION
In IOS version below 9.x.x and below the [request](https://github.com/i18next/i18next-http-backend/blob/ce7b6ef03ff7a5287ba15b51c550e56710857571/lib/request.js#L121) function does not get run due to [webkit](https://developer.apple.com/library/archive/documentation/AppleApplications/Conceptual/SafariJSProgTopics/XHR.html) returning the `XMLHttpRequest` as an `object` rather than a `function`.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [ ] documentation is changed or added