### PR TITLE
Allow rejection of attempted load via returning falsy loadPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ for plain browser:
   // function(lngs, namespaces) { return customPath; }
   // the returned path will interpolate lng, ns if provided like giving a static path
   // the function might return a promise
+  // returning falsy will abort the download
   //
   // If allowMultiLoading is false, lngs and namespaces will have only one element each,
   // If allowMultiLoading is true, lngs and namespaces can have multiple elements

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,7 @@ class Backend {
     loadPath = makePromise(loadPath)
 
     loadPath.then(resolvedLoadPath => {
-      if (!resolvedLoadPath) return callback(null, false)
+      if (!resolvedLoadPath) return callback(null, {})
       const url = this.services.interpolator.interpolate(resolvedLoadPath, { lng: languages.join('+'), ns: namespaces.join('+') })
       this.loadUrl(url, callback, loadUrlLanguages, loadUrlNamespaces)
     })

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,6 +59,7 @@ class Backend {
     loadPath = makePromise(loadPath)
 
     loadPath.then(resolvedLoadPath => {
+      if (!resolvedLoadPath) return callback(null, false)
       const url = this.services.interpolator.interpolate(resolvedLoadPath, { lng: languages.join('+'), ns: namespaces.join('+') })
       this.loadUrl(url, callback, loadUrlLanguages, loadUrlNamespaces)
     })

--- a/test/http.spec.js
+++ b/test/http.spec.js
@@ -192,7 +192,7 @@ describe(`http backend using ${hasXMLHttpRequest ? 'XMLHttpRequest' : 'fetch'}`,
           expect(err).not.to.be.ok()
           expect(calledLanguages).to.eql(['en'])
           expect(calledNamespaces).to.eql(['test'])
-          expect(data).to.eql(false)
+          expect(data).to.eql({})
           done()
         })
       })

--- a/test/http.spec.js
+++ b/test/http.spec.js
@@ -165,6 +165,40 @@ describe(`http backend using ${hasXMLHttpRequest ? 'XMLHttpRequest' : 'fetch'}`,
     })
   })
 
+  describe('with loadPath function returning falsy', () => {
+    let backend
+    let calledLanguages = []
+    let calledNamespaces = []
+    const loadPathSpy = (languages, namespaces) => {
+      calledLanguages = calledLanguages.concat(languages)
+      calledNamespaces = calledNamespaces.concat(namespaces)
+      return ''
+    }
+
+    before(() => {
+      backend = new Http(
+        {
+          interpolator: i18next.services.interpolator
+        },
+        {
+          loadPath: loadPathSpy
+        }
+      )
+    })
+
+    describe('#read', () => {
+      it('should not load data', (done) => {
+        backend.read('en', 'test', (err, data) => {
+          expect(err).not.to.be.ok()
+          expect(calledLanguages).to.eql(['en'])
+          expect(calledNamespaces).to.eql(['test'])
+          expect(data).to.eql(false)
+          done()
+        })
+      })
+    })
+  })
+
   describe('with addPath function', () => {
     let backend
     const calledLanguages = []


### PR DESCRIPTION
### Reasoning for feature
As part of the plugin system for the web app I'm working on, I would like to provide the ability for plugins to provide all their translations at once or a url path to their json translation files.

When providing all the translations at once, changing language results in the default namespace's translations also being loaded in to the plugins namespace. (due to static loadPath)

To solve these issues I would like to be able to stop a translation download if a url is not stored for the loading namespace

### How I intend to use this feature within the web app:
``` javascript
loadPath: (langs, namespaces) => {
    // If allowMultiLoading is false, langs and namespaces will have only one element
    const namespace = namespaces[0];
    return (namespace === 'translation') ?
        'static/locales/{{lng}}.json' :
        api.translationUrls[namespace];
},
```