### PR TITLE
parseLoadPayload for POST request

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,12 @@ for plain browser:
   // here it removes the letter a from the json (bad idea)
   parse: function(data) { return data.replace(/a/g, ''); },
 
-  //parse data before it has been sent by addPath
-  parsePayload: function(namespace, key, fallbackValue) { return { key } },
+  // parse data before it has been sent by addPath
+  parsePayload: function(namespace, key, fallbackValue) { return { key: fallbackValue || "" } },
+
+  // parse data before it has been sent by loadPath
+  // if value return it will send a POST request
+  parseLoadPayload: function(languages, namespaces) { return undefined },
 
   // allow cross domain requests
   crossDomain: false,

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ for plain browser:
   parsePayload: function(namespace, key, fallbackValue) { return { key: fallbackValue || "" } },
 
   // parse data before it has been sent by loadPath
-  // if value return it will send a POST request
+  // if value returned it will send a POST request
   parseLoadPayload: function(languages, namespaces) { return undefined },
 
   // allow cross domain requests

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,6 +47,14 @@ export interface HttpBackendOptions {
     fallbackValue?: string
   ): { [key: string]: any };
   /**
+   * parse data before it has been sent by loadPath
+   * if value return it will send a POST request
+   */
+  parseLoadPayload?(
+    languages: string[],
+    namespaces: string[]
+  ): { [key: string]: any } | undefined;
+  /**
    * allow cross domain requests
    */
   crossDomain?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -48,7 +48,7 @@ export interface HttpBackendOptions {
   ): { [key: string]: any };
   /**
    * parse data before it has been sent by loadPath
-   * if value return it will send a POST request
+   * if value returned it will send a POST request
    */
   parseLoadPayload?(
     languages: string[],

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ const getDefaults = () => {
     parse: data => JSON.parse(data),
     stringify: JSON.stringify,
     parsePayload: (namespace, key, fallbackValue) => ({ [key]: fallbackValue || '' }),
+    parseLoadPayload: (languages, namespaces) => undefined,
     request,
     reloadInterval: typeof window !== 'undefined' ? false : 60 * 60 * 1000,
     customHeaders: {},
@@ -66,7 +67,11 @@ class Backend {
   }
 
   loadUrl (url, callback, languages, namespaces) {
-    this.options.request(this.options, url, undefined, (err, res) => {
+    if (typeof languages === 'string') languages = [languages]
+    if (typeof namespaces === 'string') namespaces = [namespaces]
+    // parseLoadPayload — default undefined
+    const payload = this.options.parseLoadPayload(languages, namespaces)
+    this.options.request(this.options, url, payload, (err, res) => {
       if (res && ((res.status >= 500 && res.status < 600) || !res.status)) return callback('failed loading ' + url + '; status code: ' + res.status, true /* retry */)
       if (res && res.status >= 400 && res.status < 500) return callback('failed loading ' + url + '; status code: ' + res.status, false /* no retry */)
       if (!res && err && err.message && err.message.indexOf('Failed to fetch') > -1) return callback('failed loading ' + url + ': ' + err.message, true /* retry */)

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,10 +67,10 @@ class Backend {
   }
 
   loadUrl (url, callback, languages, namespaces) {
-    if (typeof languages === 'string') languages = [languages]
-    if (typeof namespaces === 'string') namespaces = [namespaces]
+    const lng = (typeof languages === 'string') ? [languages] : languages
+    const ns = (typeof namespaces === 'string') ? [namespaces] : namespaces
     // parseLoadPayload — default undefined
-    const payload = this.options.parseLoadPayload(languages, namespaces)
+    const payload = this.options.parseLoadPayload(lng, ns)
     this.options.request(this.options, url, payload, (err, res) => {
       if (res && ((res.status >= 500 && res.status < 600) || !res.status)) return callback('failed loading ' + url + '; status code: ' + res.status, true /* retry */)
       if (res && res.status >= 400 && res.status < 500) return callback('failed loading ' + url + '; status code: ' + res.status, false /* no retry */)


### PR DESCRIPTION
Adding parseLoadPayload for POST request.

For everybody working with GraphQL or who would like to send a POST request - the parseLoadPayload function will be handy. It gets access to languages and namespaces and can parse the data before it has been sent by loadPath.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)