### PR TITLE
Fix for method override in requestOptions not working

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -70,11 +70,11 @@ const requestWithFetch = (options, url, payload, callback) => {
   }
   if (payload) headers['Content-Type'] = 'application/json'
   const reqOptions = typeof options.requestOptions === 'function' ? options.requestOptions(payload) : options.requestOptions
-  const fetchOptions = defaults({
+  const fetchOptions = defaults(omitFetchOptions ? {} : reqOptions, {
     method: payload ? 'POST' : 'GET',
     body: payload ? options.stringify(payload) : undefined,
     headers
-  }, omitFetchOptions ? {} : reqOptions)
+  })
   try {
     fetchIt(url, fetchOptions, callback)
   } catch (e) {


### PR DESCRIPTION
While implementing an Airtable based backend, I discovered that overriding the HTTP method (in this case to `PATCH` to do an upsert) is not working as it should, even though the documentation explicitly mentions this example:

<img width="788" alt="image" src="https://github.com/i18next/i18next-http-backend/assets/159500/95916ed6-48b2-43c3-a836-2074858e5e2f">
.

To test, use config: `requestOptions: { method: 'PATCH' }`. Before this fix, any `saveMissing` or `updateMissing` calls would still have method: POST.

I believe the issue is an incorrect use of [`defaults()`](https://github.com/i18next/i18next-http-backend/blob/bffae37ba5ecbcef8bf1ddf09e23644dcc85a11e/lib/utils.js#L5-L14), where the default values are put first in the parameter list, while it appears the function expects them to be the last (although, it is an unclear signature).