### PR TITLE
fix: remove typeof window.document === 'undefined' check which deopt bundle optimization

### DIFF
--- a/lib/getFetch.cjs
+++ b/lib/getFetch.cjs
@@ -10,7 +10,7 @@ if (typeof fetch === 'function') {
   }
 }
 
-if (typeof require !== 'undefined' && (typeof window === 'undefined' || typeof window.document === 'undefined')) {
+if (typeof require !== 'undefined' && typeof window === 'undefined') {
   var f = fetchApi || require('cross-fetch')
   if (f.default) f = f.default
   exports.default = f


### PR DESCRIPTION
fixes #136 

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

with default bundle define config of `typeof window` === `"object"` in browser env the lib gets removed
![image](https://github.com/i18next/i18next-http-backend/assets/9304194/9ad20537-69b7-4c90-82d3-1662698dd5d4)
