### PR TITLE
fix variables not nullable in request callback typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -103,7 +103,7 @@ export interface HttpBackendOptions {
   requestOptions?: RequestInit | ((payload: {} | string) => RequestInit);
 }
 
-type RequestCallback = (error: any, response: RequestResponse) => void;
+type RequestCallback = (error: any | undefined | null, response: RequestResponse | undefined | null) => void;
 
 interface RequestResponse {
   status: number;


### PR DESCRIPTION
The RequestCallback type definition didn't mention that both of its parameters are nullable. This is especially confusing since the documentation explicitly mentions the response parameter as being nullable.

#### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test`
- [ ] tests are included
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)