### PR TITLE
Add usage instructions for plain vanilla JS browser integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ for plain browser:
 <!-- an example can be found in example/jquery/index.html -->
 ```
 
+```js
+i18next.use(i18nextHttpBackend).init(i18nextOptions);
+```
+
 - As with all modules you can either pass the constructor function (class) to the i18next.use or a concrete instance.
 - If you don't use a module loader it will be added to `window.i18nextHttpBackend`
 


### PR DESCRIPTION
Includes missing instructions on how to use the i18next-http-backend with plain vanilla / browser JavaScript.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)